### PR TITLE
Fix: build profile

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: "17"
 
       - name: 🚀 Build app
-        run: eas build --non-interactive --platform android --profile preview --local
+        run: eas build --non-interactive --platform android --profile production --local
 
       - name: 📤 Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: "17"
 
       - name: 🚀 Build app
-        run: eas build --non-interactive --platform android --profile development --local
+        run: eas build --non-interactive --platform android --profile preview --local
 
       - name: 📤 Upload APK
         uses: actions/upload-artifact@v4

--- a/eas.json
+++ b/eas.json
@@ -10,6 +10,21 @@
       "android": {
         "image": "latest",
         "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "image": "latest",
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "distribution": "internal",
+      "android": {
+        "image": "latest",
+        "buildType": "apk"
       },
       "env": {
         "EXPO_PUBLIC_FIREBASE_API_KEY": "AIzaSyBkMkNI0ShOWKByQDYNh6sFxAS0xgd1wA0",
@@ -23,14 +38,6 @@
         "EXPO_PUBLIC_IOS_CLIENT_ID_OAUTH": "78136023669-fgnhdh3eee7shnn16htndvefr7ias1vb.apps.googleusercontent.com",
         "EXPO_PUBLIC_ANDROID_CLIENT_IDOAUTH": "78136023669-1c00r0e1bvmv7nt10c758m3p0gdf5gbf.apps.googleusercontent.com"
       }
-    },
-    "preview": {
-      "distribution": "internal",
-      "android": {
-        "image": "latest",
-        "buildType": "apk"
-      }
-    },
-    "production": {}
+    }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -25,7 +25,11 @@
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "image": "latest",
+        "buildType": "apk"
+      }
     },
     "production": {}
   }


### PR DESCRIPTION
This pull request includes changes to the build configuration for Android in the `.github/workflows/build_apk.yml` and `eas.json` files. The most important changes include updating the build profile to production in the GitHub workflow and restructuring the `eas.json` file to include additional build profiles and settings. This was needed as an APK was created, but still needed a development server, making it unusable by itself. 

## Changes
- Switched to `production` build.
- Adapted `production` build setting to create a working APK.