### PR TITLE
fix: DBChallengeDescription type and implementation in home screen

### DIFF
--- a/__tests__/UI-tests/home/home.test.tsx
+++ b/__tests__/UI-tests/home/home.test.tsx
@@ -9,12 +9,12 @@ import {
 import HomeScreen from "@/app/screens/home/home_screen";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import FirestoreCtrl from "@/firebase/FirestoreCtrl";
-import {
+import FirestoreCtrl, {
   DBChallenge,
   DBGroup,
   DBChallengeDescription,
 } from "@/firebase/FirestoreCtrl";
+import { Timestamp } from "@/firebase/Firebase";
 
 const Stack = createNativeStackNavigator();
 
@@ -60,6 +60,7 @@ const mockGroups: DBGroup[] = [
 const mockChallengeDescription: DBChallengeDescription = {
   title: "Challenge Title",
   description: "Challenge Description",
+  timeStamp: new Timestamp(0, 0),
   endDate: new Date(2024, 1, 1, 0, 0, 0, 0),
 };
 

--- a/__tests__/UI-tests/home/home.test.tsx
+++ b/__tests__/UI-tests/home/home.test.tsx
@@ -14,7 +14,6 @@ import FirestoreCtrl, {
   DBGroup,
   DBChallengeDescription,
 } from "@/firebase/FirestoreCtrl";
-import { Timestamp } from "@/firebase/Firebase";
 
 const Stack = createNativeStackNavigator();
 
@@ -60,7 +59,6 @@ const mockGroups: DBGroup[] = [
 const mockChallengeDescription: DBChallengeDescription = {
   title: "Challenge Title",
   description: "Challenge Description",
-  timeStamp: new Timestamp(0, 0),
   endDate: new Date(2024, 1, 1, 0, 0, 0, 0),
 };
 

--- a/app/screens/home/home_screen.tsx
+++ b/app/screens/home/home_screen.tsx
@@ -17,6 +17,7 @@ import FirestoreCtrl, {
 } from "@/firebase/FirestoreCtrl";
 import { ChallengeDescription } from "@/components/home/Challenge_Description";
 import { DBChallengeDescription } from "@/firebase/FirestoreCtrl";
+import { Timestamp } from "firebase/firestore";
 
 const { width, height } = Dimensions.get("window");
 
@@ -42,28 +43,31 @@ export default function HomeScreen({
     title: "Challenge Title",
     description: "Challenge Description",
     endDate: new Date(2024, 1, 1, 0, 0, 0, 0),
+    timeStamp: Timestamp.fromDate(new Date(2024, 1, 1, 0, 0, 0, 0)),
   });
 
   // Fetch the current challenge description
   useEffect(() => {
     const fetchCurrentChallenge = async () => {
       try {
-        const currentChallengeData =
-          await firestoreCtrl.getChallengeDescription();
-
+        const currentChallengeData = await firestoreCtrl.getChallengeDescription();
+  
+        // Convert the Timestamp to a Date
         const formattedChallenge = {
-          title: currentChallengeData.Title,
-          description: currentChallengeData.Description,
-          endDate: new Date(currentChallengeData.Date.seconds * 1000), // Conversion Timestamp -> Date
+          title: currentChallengeData.title,
+          description: currentChallengeData.description,
+          timeStamp: currentChallengeData.timeStamp,
+          endDate: currentChallengeData.timeStamp.toDate(),
         };
-
+  
         setTitleChallenge(formattedChallenge);
       } catch (error) {
         console.error("Error fetching current challenge: ", error);
       }
     };
+  
     fetchCurrentChallenge();
-  });
+  }, []);
 
   // Fetch the list of challenges
   useEffect(() => {

--- a/app/screens/home/home_screen.tsx
+++ b/app/screens/home/home_screen.tsx
@@ -8,16 +8,14 @@ import { ThemedView } from "@/components/theme/ThemedView";
 import { BottomBar } from "@/components/navigation/BottomBar";
 import { ThemedText } from "@/components/theme/ThemedText";
 import { ThemedTextButton } from "@/components/theme/ThemedTextButton";
-import { Colors } from "@/constants/Colors";
-import { color } from "react-native-elements/dist/helpers";
 import FirestoreCtrl, {
   DBChallenge,
   DBUser,
   DBGroup,
+  DBChallengeDescription
 } from "@/firebase/FirestoreCtrl";
+import { Timestamp } from "@/firebase/Firebase";
 import { ChallengeDescription } from "@/components/home/Challenge_Description";
-import { DBChallengeDescription } from "@/firebase/FirestoreCtrl";
-import { Timestamp } from "firebase/firestore";
 
 const { width, height } = Dimensions.get("window");
 

--- a/app/screens/home/home_screen.tsx
+++ b/app/screens/home/home_screen.tsx
@@ -41,7 +41,6 @@ export default function HomeScreen({
     title: "Challenge Title",
     description: "Challenge Description",
     endDate: new Date(2024, 1, 1, 0, 0, 0, 0),
-    timeStamp: Timestamp.fromDate(new Date(2024, 1, 1, 0, 0, 0, 0)),
   });
 
   // Fetch the current challenge description
@@ -54,10 +53,8 @@ export default function HomeScreen({
         const formattedChallenge = {
           title: currentChallengeData.title,
           description: currentChallengeData.description,
-          timeStamp: currentChallengeData.timeStamp,
-          endDate: currentChallengeData.timeStamp.toDate(),
+          endDate: currentChallengeData.endDate instanceof Timestamp ? currentChallengeData.endDate.toDate() : currentChallengeData.endDate,
         };
-  
         setTitleChallenge(formattedChallenge);
       } catch (error) {
         console.error("Error fetching current challenge: ", error);

--- a/app/screens/home/home_screen.tsx
+++ b/app/screens/home/home_screen.tsx
@@ -12,7 +12,7 @@ import FirestoreCtrl, {
   DBChallenge,
   DBUser,
   DBGroup,
-  DBChallengeDescription
+  DBChallengeDescription,
 } from "@/firebase/FirestoreCtrl";
 import { Timestamp } from "@/firebase/Firebase";
 import { ChallengeDescription } from "@/components/home/Challenge_Description";
@@ -47,20 +47,24 @@ export default function HomeScreen({
   useEffect(() => {
     const fetchCurrentChallenge = async () => {
       try {
-        const currentChallengeData = await firestoreCtrl.getChallengeDescription();
-  
+        const currentChallengeData =
+          await firestoreCtrl.getChallengeDescription();
+
         // Convert the Timestamp to a Date
         const formattedChallenge = {
           title: currentChallengeData.title,
           description: currentChallengeData.description,
-          endDate: currentChallengeData.endDate instanceof Timestamp ? currentChallengeData.endDate.toDate() : currentChallengeData.endDate,
+          endDate:
+            currentChallengeData.endDate instanceof Timestamp
+              ? currentChallengeData.endDate.toDate()
+              : currentChallengeData.endDate,
         };
         setTitleChallenge(formattedChallenge);
       } catch (error) {
         console.error("Error fetching current challenge: ", error);
       }
     };
-  
+
     fetchCurrentChallenge();
   }, []);
 

--- a/firebase/Firebase.tsx
+++ b/firebase/Firebase.tsx
@@ -28,9 +28,8 @@ import {
   where,
   Firestore,
   onSnapshot,
+  Timestamp,
 } from "firebase/firestore";
-
-import { Timestamp } from "firebase-admin/firestore";
 
 // https://firebase.google.com/docs/web/setup#available-libraries
 

--- a/firebase/Firebase.tsx
+++ b/firebase/Firebase.tsx
@@ -30,6 +30,8 @@ import {
   onSnapshot,
 } from "firebase/firestore";
 
+import { Timestamp } from "firebase-admin/firestore";
+
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Your web app's Firebase configuration
@@ -82,4 +84,5 @@ export {
   signInAnonymously,
   updateEmail,
   signOut,
+  Timestamp,
 };

--- a/firebase/FirestoreCtrl.ts
+++ b/firebase/FirestoreCtrl.ts
@@ -1,4 +1,4 @@
-import { FieldPath, limit, documentId, GeoPoint } from "firebase/firestore";
+import { FieldPath, limit, documentId, GeoPoint, FirestoreDataConverter, Timestamp } from "firebase/firestore";
 
 import {
   firestore,
@@ -55,7 +55,8 @@ export type DBGroup = {
 export type DBChallengeDescription = {
   title: string;
   description: string;
-  endDate: Date;
+  timeStamp: Timestamp;
+  endDate?: Date;
 };
 
 export default class FirestoreCtrl {

--- a/firebase/FirestoreCtrl.ts
+++ b/firebase/FirestoreCtrl.ts
@@ -1,5 +1,4 @@
-import { FieldPath, limit, documentId, GeoPoint, FirestoreDataConverter, Timestamp } from "firebase/firestore";
-
+import { FieldPath, limit, documentId, GeoPoint, FirestoreDataConverter } from "firebase/firestore";
 import {
   firestore,
   doc,
@@ -11,6 +10,7 @@ import {
   collection,
   query,
   where,
+  Timestamp,
 } from "./Firebase";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { LocationObject, LocationObjectCoords } from "expo-location";

--- a/firebase/FirestoreCtrl.ts
+++ b/firebase/FirestoreCtrl.ts
@@ -55,8 +55,7 @@ export type DBGroup = {
 export type DBChallengeDescription = {
   title: string;
   description: string;
-  timeStamp: Timestamp;
-  endDate?: Date;
+  endDate: Date|Timestamp;
 };
 
 export default class FirestoreCtrl {

--- a/firebase/FirestoreCtrl.ts
+++ b/firebase/FirestoreCtrl.ts
@@ -1,4 +1,10 @@
-import { FieldPath, limit, documentId, GeoPoint, FirestoreDataConverter } from "firebase/firestore";
+import {
+  FieldPath,
+  limit,
+  documentId,
+  GeoPoint,
+  FirestoreDataConverter,
+} from "firebase/firestore";
 import {
   firestore,
   doc,
@@ -55,7 +61,7 @@ export type DBGroup = {
 export type DBChallengeDescription = {
   title: string;
   description: string;
-  endDate: Date|Timestamp;
+  endDate: Date | Timestamp;
 };
 
 export default class FirestoreCtrl {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "expo-system-ui": "~4.0.2",
     "expo-web-browser": "~14.0.1",
     "firebase": "^11.0.1",
-    "firebase-admin": "^12.6.0",
+    "firebase-admin": "^12.7.0",
     "js-cookie": "^3.0.5",
     "metro": "^0.81.0",
     "metro-cache-key": "^0.81.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "expo-system-ui": "~4.0.2",
     "expo-web-browser": "~14.0.1",
     "firebase": "^11.0.1",
-    "firebase-admin": "^12.7.0",
     "js-cookie": "^3.0.5",
     "metro": "^0.81.0",
     "metro-cache-key": "^0.81.0",


### PR DESCRIPTION
This pull request includes changes to the `HomeScreen` component and the `FirestoreCtrl` module to handle Firestore Timestamps more effectively. The most important changes involve importing the `Timestamp` class from Firestore, updating the `DBChallengeDescription` type, and modifying how challenge data is fetched and formatted.

### Handling Firestore Timestamps:

* [`app/screens/home/home_screen.tsx`](diffhunk://#diff-6526ae8a24a7d12b3c578f5add3c25b6adff57eec7ca6c7c8010da92c01e1b59R20): Imported `Timestamp` from Firestore and added a `timeStamp` field to the `initialState` object. Updated the `fetchCurrentChallenge` function to handle the `Timestamp` conversion properly. [[1]](diffhunk://#diff-6526ae8a24a7d12b3c578f5add3c25b6adff57eec7ca6c7c8010da92c01e1b59R20) [[2]](diffhunk://#diff-6526ae8a24a7d12b3c578f5add3c25b6adff57eec7ca6c7c8010da92c01e1b59R46-R70)

* [`firebase/FirestoreCtrl.ts`](diffhunk://#diff-68f274fee87b5e470e12a5077cb5265798b80ae2754ce5ccc1c93629b02cd73eL1-R1): Imported `Timestamp` from Firestore and updated the `DBChallengeDescription` type to include a `timeStamp` field and make `endDate` optional. [[1]](diffhunk://#diff-68f274fee87b5e470e12a5077cb5265798b80ae2754ce5ccc1c93629b02cd73eL1-R1) [[2]](diffhunk://#diff-68f274fee87b5e470e12a5077cb5265798b80ae2754ce5ccc1c93629b02cd73eL58-R59)