### PR TITLE
Feat: home posts location

### DIFF
--- a/app/screens/home/maximize_screen.tsx
+++ b/app/screens/home/maximize_screen.tsx
@@ -12,7 +12,7 @@ import FirestoreCtrl, {
   DBComment,
   DBUser,
 } from "@/firebase/FirestoreCtrl";
-import { Timestamp } from "firebase/firestore";
+import { GeoPoint, Timestamp } from "firebase/firestore";
 import { LocationObject } from "expo-location";
 
 const { width, height } = Dimensions.get("window");
@@ -133,12 +133,7 @@ export default function MaximizeScreen({
                   navigation: navigation,
                   user: user,
                   firestoreCtrl: firestoreCtrl,
-                  location: {
-                    coords: {
-                      latitude: challenge.location?.latitude,
-                      longitude: challenge.location?.longitude,
-                    },
-                  } as LocationObject,
+                  location: challenge.location,
                 });
               }}
               size={25}

--- a/app/screens/home/maximize_screen.tsx
+++ b/app/screens/home/maximize_screen.tsx
@@ -13,6 +13,7 @@ import FirestoreCtrl, {
   DBUser,
 } from "@/firebase/FirestoreCtrl";
 import { Timestamp } from "firebase/firestore";
+import { LocationObject } from "expo-location";
 
 const { width, height } = Dimensions.get("window");
 
@@ -112,7 +113,7 @@ export default function MaximizeScreen({
               colorType="white"
             />
 
-            {/* User name and location */}
+            {/* User name and date */}
             <ThemedView style={styles.userInfo} colorType="transparent">
               <ThemedText colorType="white" type="smallSemiBold">
                 {postUser?.name}
@@ -124,31 +125,43 @@ export default function MaximizeScreen({
           </ThemedView>
 
           {/* Location button */}
-          <ThemedIconButton
-            name="location-outline"
-            onPress={() => {
-              /* location button */
-            }}
-            size={25}
-            colorType="white"
-          />
+          {challenge.location && (
+            <ThemedIconButton
+              name="location-outline"
+              onPress={() => {
+                navigation.navigate("MapScreen", {
+                  navigation: navigation,
+                  user: user,
+                  firestoreCtrl: firestoreCtrl,
+                  location: {
+                    coords: {
+                      latitude: challenge.location?.latitude,
+                      longitude: challenge.location?.longitude,
+                    },
+                  } as LocationObject,
+                });
+              }}
+              size={25}
+              colorType="white"
+            />
+          )}
         </ThemedView>
 
         {/* Image */}
-          <ThemedView
-            style={styles.container}
-            colorType="transparent"
-            testID="challenge-image"
-          >
-            <Image
-              source={
-                postImage
-                  ? { uri: postImage }
-                  : require("@/assets/images/no-image.svg")
-              }
-              style={styles.image}
-            />
-          </ThemedView>
+        <ThemedView
+          style={styles.container}
+          colorType="transparent"
+          testID="challenge-image"
+        >
+          <Image
+            source={
+              postImage
+                ? { uri: postImage }
+                : require("@/assets/images/no-image.svg")
+            }
+            style={styles.image}
+          />
+        </ThemedView>
 
         {/* Like section */}
         <ThemedView style={styles.likeSection} colorType="transparent">

--- a/app/screens/map/map_screen.tsx
+++ b/app/screens/map/map_screen.tsx
@@ -32,14 +32,19 @@ export default function MapScreen({
   user,
   navigation,
   firestoreCtrl,
+  route,
 }: {
   user: DBUser;
   navigation: any;
   firestoreCtrl: FirestoreCtrl;
+  route: any;
 }) {
+  // Sets the first location to the location provided in the route parameters, if available.
+  const firstLocation =
+    route.params != undefined ? route.params.location : undefined;
   const [permission, setPermission] = useState<boolean>(false);
   const [userLocation, setUserPosition] = useState<LocationObject | undefined>(
-    undefined,
+    firstLocation,
   );
   const [challengesWithLocation, setChallengesWithLocation] = useState<
     DBChallenge[]
@@ -49,6 +54,10 @@ export default function MapScreen({
    * Asks for permission to access the user's location and sets the location state to the user's current location.
    */
   useEffect(() => {
+    /**
+     * Gets the user's current location and sets the location state to the user's current location.
+     * This function is called only if no first location was provided when calling the MapScreen component.
+     */
     async function getCurrentLocation() {
       try {
         const { status } = await requestForegroundPermissionsAsync();
@@ -66,7 +75,9 @@ export default function MapScreen({
       }
     }
 
-    getCurrentLocation();
+    if (firstLocation === undefined) {
+      getCurrentLocation();
+    }
   }, []);
 
   /**

--- a/app/screens/map/map_screen.tsx
+++ b/app/screens/map/map_screen.tsx
@@ -1,26 +1,19 @@
 import React, { useState, useEffect } from "react";
 import { StyleSheet } from "react-native";
-import MapView, { LatLng, MapMarker } from "react-native-maps";
+import MapView, { MapMarker } from "react-native-maps";
 import {
   requestForegroundPermissionsAsync,
   getCurrentPositionAsync,
-  LocationObject,
 } from "expo-location";
+import { GeoPoint } from "firebase/firestore";
 import { ThemedView } from "@/components/theme/ThemedView";
 import { ThemedText } from "@/components/theme/ThemedText";
 import { TopBar } from "@/components/navigation/TopBar";
 import FirestoreCtrl, { DBChallenge, DBUser } from "@/firebase/FirestoreCtrl";
-// import { DBChallenge } from "@/firebase/FirestoreCtrl";
-
 /**
  * The default location object, centered on the city of Nice, France.
  */
-const defaultLocation = {
-  coords: {
-    latitude: 43.6763,
-    longitude: 7.0122,
-  },
-} as LocationObject;
+const defaultLocation = new GeoPoint(43.6763, 7.0122);
 
 /**
  * The MapScreen component displays a map centered on the user's current location, if available.
@@ -40,10 +33,9 @@ export default function MapScreen({
   route: any;
 }) {
   // Sets the first location to the location provided in the route parameters, if available.
-  const firstLocation =
-    route.params != undefined ? route.params.location : undefined;
+  const firstLocation: GeoPoint | undefined = route.params?.location;
   const [permission, setPermission] = useState<boolean>(false);
-  const [userLocation, setUserPosition] = useState<LocationObject | undefined>(
+  const [userLocation, setUserPosition] = useState<GeoPoint | undefined>(
     firstLocation,
   );
   const [challengesWithLocation, setChallengesWithLocation] = useState<
@@ -65,7 +57,9 @@ export default function MapScreen({
         if (status === "granted") {
           setPermission(true);
           const location = await getCurrentPositionAsync();
-          setUserPosition(location);
+          setUserPosition(
+            new GeoPoint(location.coords.latitude, location.coords.longitude),
+          );
         } else {
           setPermission(false);
           setUserPosition(defaultLocation);
@@ -127,10 +121,10 @@ export default function MapScreen({
         style={styles.map}
         testID="mapView"
         initialRegion={{
-          latitude: userLocation?.coords.latitude ?? 0,
-          longitude: userLocation?.coords.longitude ?? 0,
-          latitudeDelta: 0.0,
-          longitudeDelta: 0.0,
+          latitude: userLocation?.latitude ?? 0,
+          longitude: userLocation?.longitude ?? 0,
+          latitudeDelta: 0.0922,
+          longitudeDelta: 0.0421,
         }}
         zoomControlEnabled={true}
         mapType="standard"

--- a/app/screens/map/map_screen.tsx
+++ b/app/screens/map/map_screen.tsx
@@ -138,6 +138,14 @@ export default function MapScreen({
             flat={true}
             title={challengeWithLocation.challenge_name}
             description={challengeWithLocation.description}
+            onCalloutPress={() => {
+              console.log("Challenge pressed: ", challengeWithLocation);
+              navigation.navigate("Maximize", {
+                challenge: challengeWithLocation,
+                user: user,
+                firestoreCtrl: firestoreCtrl,
+              });
+            }}
           />
         ))}
       </MapView>

--- a/app/screens/map/map_screen.tsx
+++ b/app/screens/map/map_screen.tsx
@@ -100,7 +100,7 @@ export default function MapScreen({
     };
 
     fetchChallenges();
-  }, []);
+  });
 
   /**
    * Renders a loading message while the location is being fetched.

--- a/components/home/Challenge.tsx
+++ b/components/home/Challenge.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from "@/components/theme/ThemedText";
 import { ThemedView } from "@/components/theme/ThemedView";
 import { ThemedIconButton } from "@/components/theme/ThemedIconButton";
 import FirestoreCtrl, { DBChallenge, DBUser } from "@/firebase/FirestoreCtrl";
+import { LocationObject } from "expo-location";
 
 const { width, height } = Dimensions.get("window");
 
@@ -153,14 +154,26 @@ export function Challenge({
                       );
                     }}
                   />
-                  <ThemedIconButton
-                    name="location-outline"
-                    onPress={() => {
-                      /* location button */
-                    }}
-                    size={25}
-                    color="white"
-                  />
+                  {challengeDB.location && (
+                    <ThemedIconButton
+                      name="location-outline"
+                      onPress={() => {
+                        navigation.navigate("MapScreen", {
+                          navigation: navigation,
+                          firestoreCtrl: firestoreCtrl,
+                          user: currentUser,
+                          location: {
+                            coords: {
+                              latitude: challengeDB.location?.latitude,
+                              longitude: challengeDB.location?.longitude,
+                            },
+                          } as LocationObject,
+                        });
+                      }}
+                      size={25}
+                      color="white"
+                    />
+                  )}
                 </ThemedView>
               </ThemedView>
             )}

--- a/components/home/Challenge.tsx
+++ b/components/home/Challenge.tsx
@@ -57,7 +57,7 @@ export function Challenge({
         setIsLiked(likes.includes(currentUser.uid));
         setLikes(likes);
       });
-  }, [challengeDB.challenge_id]);
+  });
 
   // Display loading state or handle absence of challenge data
   if (!challengeDB) {

--- a/components/home/Challenge.tsx
+++ b/components/home/Challenge.tsx
@@ -162,12 +162,7 @@ export function Challenge({
                           navigation: navigation,
                           firestoreCtrl: firestoreCtrl,
                           user: currentUser,
-                          location: {
-                            coords: {
-                              latitude: challengeDB.location?.latitude,
-                              longitude: challengeDB.location?.longitude,
-                            },
-                          } as LocationObject,
+                          location: challengeDB.location,
                         });
                       }}
                       size={25}


### PR DESCRIPTION
This PR allows the locations buttons of the `Challenge` component and the `Maximize` screen to be used.

# Changes
We can now:
- Click on the location button of the `Challenge` component to go to the `Map` screen centered around the location of the challenge
- Click on the location button of the `Maximize` screen to go to the `Map` screen centered around the location of the challenge
- Not see the location buttons if the challenge does not have a location

# Fix
Some issues with the `useEffect` functions inside those files were fixed for a better retrieval of the data.