### PR TITLE
Fix: location buttons

### DIFF
--- a/__tests__/View-tests/map/mapScreen-test.tsx
+++ b/__tests__/View-tests/map/mapScreen-test.tsx
@@ -67,6 +67,7 @@ describe("MapScreen UI Tests", () => {
         user={mockUser}
         navigation={mockNavigation}
         firestoreCtrl={mockFirestoreCtrl}
+        route={{}}
       />,
     );
 
@@ -90,6 +91,7 @@ describe("MapScreen UI Tests", () => {
         user={mockUser}
         navigation={mockNavigation}
         firestoreCtrl={mockFirestoreCtrl}
+        route={{}}
       />,
     );
 

--- a/app/src/viewmodels/home/HomeScreenViewModel.tsx
+++ b/app/src/viewmodels/home/HomeScreenViewModel.tsx
@@ -27,7 +27,7 @@ export function useHomeScreenViewModel(
     endDate: new Date(2024, 1, 1, 0, 0, 0, 0),
   });
   const navigateToProfile = () => navigation.navigate("Profile");
-  const navigateToMap = () => navigation.navigate("Map");
+  const navigateToMap = () => navigation.navigate("MapScreen");
   const navigateToCamera = () => navigation.navigate("Camera");
   const navigateToFriends = () => navigation.navigate("Friends");
 

--- a/app/src/views/map/map_screen.tsx
+++ b/app/src/views/map/map_screen.tsx
@@ -26,12 +26,12 @@ export default function MapScreen({
   route: any;
 }) {
   const firstLocation = route.params?.location;
-  const { permission, userLocation, challengesWithLocation, navigateGoBack } =
+  const { userLocation, challengesWithLocation, navigateGoBack } =
     useMapScreenViewModel(firestoreCtrl, navigation, firstLocation);
 
   const uri = "@/assets/images/icon_trans.png";
 
-  if (!permission && userLocation === undefined) {
+  if (userLocation === undefined) {
     return (
       <ThemedView>
         <ThemedText>Getting location...</ThemedText>
@@ -49,8 +49,8 @@ export default function MapScreen({
       <MapView
         style={styles.map}
         initialRegion={{
-          latitude: userLocation?.latitude ?? 0,
-          longitude: userLocation?.longitude ?? 0,
+          latitude: userLocation.latitude,
+          longitude: userLocation.longitude,
           latitudeDelta: 0.0922,
           longitudeDelta: 0.0421,
         }}


### PR DESCRIPTION
The map had issues starting on the right location and often wrongly defaulted to (0,0), in the middle of the Atlantic Ocean. This PR makes sure this does not happen anymore ; it displays a swift loading screen before it shows the map, to be sure the location is ready no matter what.