### PR TITLE
Fix/failing test suites

### DIFF
--- a/__tests__/ViewModel-tests/camera/cameraViewModel.test.tsx
+++ b/__tests__/ViewModel-tests/camera/cameraViewModel.test.tsx
@@ -23,6 +23,12 @@ const mockNavigation = {
   navigate: jest.fn(),
 };
 
+const mockRoute = {
+  params: {
+    group_id: "mock-group-id",
+  },
+};
+
 describe("useCameraViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,7 +40,7 @@ describe("useCameraViewModel", () => {
       jest.fn(),
     ]);
     const { result } = renderHook(() =>
-      useCameraViewModel(mockFirestoreCtrl, mockNavigation),
+      useCameraViewModel(mockFirestoreCtrl, mockNavigation, mockRoute),
     );
 
     expect(result.current.facing).toBe("back");
@@ -47,7 +53,7 @@ describe("useCameraViewModel", () => {
 
   it("should toggle camera facing", () => {
     const { result } = renderHook(() =>
-      useCameraViewModel(mockFirestoreCtrl, mockNavigation),
+      useCameraViewModel(mockFirestoreCtrl, mockNavigation, mockRoute),
     );
 
     act(() => {
@@ -65,7 +71,7 @@ describe("useCameraViewModel", () => {
 
   it("should toggle flash mode", () => {
     const { result } = renderHook(() =>
-      useCameraViewModel(mockFirestoreCtrl, mockNavigation),
+      useCameraViewModel(mockFirestoreCtrl, mockNavigation, mockRoute),
     );
 
     act(() => {
@@ -94,7 +100,7 @@ describe("useCameraViewModel", () => {
     };
 
     const { result } = renderHook(() =>
-      useCameraViewModel(mockFirestoreCtrl, mockNavigation),
+      useCameraViewModel(mockFirestoreCtrl, mockNavigation, mockRoute),
     );
 
     // Set the picture state directly
@@ -109,6 +115,7 @@ describe("useCameraViewModel", () => {
 
     expect(mockFirestoreCtrl.uploadImageFromUri).toHaveBeenCalled;
     expect(mockNavigation.navigate).toHaveBeenCalledWith("CreateChallenge", {
+      group_id: "mock-group-id",
       image_id: "mock-image-id",
     });
   });
@@ -121,7 +128,7 @@ describe("useCameraViewModel", () => {
     ]);
 
     const { result } = renderHook(() =>
-      useCameraViewModel(mockFirestoreCtrl, mockNavigation),
+      useCameraViewModel(mockFirestoreCtrl, mockNavigation, mockRoute),
     );
 
     await act(async () => {

--- a/__tests__/ViewModel-tests/create/createChallengeViewModel.test.tsx
+++ b/__tests__/ViewModel-tests/create/createChallengeViewModel.test.tsx
@@ -5,6 +5,7 @@ import {
 } from "expo-location";
 import { createChallenge } from "@/types/ChallengeBuilder";
 import CreateChallengeViewModel from "@/src/viewmodels/create/CreateChallengeViewModel";
+import FirestoreCtrl from "@/src/models/firebase/FirestoreCtrl";
 
 // Mock `expo-location`
 jest.mock("expo-location", () => ({
@@ -19,17 +20,24 @@ jest.mock("@/types/ChallengeBuilder", () => ({
   createChallenge: jest.fn(),
 }));
 
+// Mock FirestoreCtrl
+jest.mock("@/src/models/firebase/FirestoreCtrl", () => {
+  return jest.fn().mockImplementation(() => ({
+    // Mock FirestoreCtrl methods
+  }));
+});
+const mockFirestoreCtrl = new FirestoreCtrl();
+
 const mockNavigation = {
-  reset: jest.fn(),
+  navigate: jest.fn(),
 };
 
 const mockRoute = {
   params: {
     image_id: "mock-image-id",
+    group_id: "home",
   },
 };
-
-const mockFirestoreCtrl = {};
 
 describe("CreateChallengeViewModel", () => {
   beforeEach(() => {
@@ -144,13 +152,11 @@ describe("CreateChallengeViewModel", () => {
       "Test Challenge",
       "Test Description",
       null, // Location is null by default
+      "home",
       expect.any(Date),
       "mock-image-id",
     );
-    expect(mockNavigation.reset).toHaveBeenCalledWith({
-      index: 0,
-      routes: [{ name: "Home" }],
-    });
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("Home");
   });
 
   it("should handle errors during challenge creation", async () => {

--- a/__tests__/ViewModel-tests/map/mapScreenViewModel.test.tsx
+++ b/__tests__/ViewModel-tests/map/mapScreenViewModel.test.tsx
@@ -80,8 +80,14 @@ describe("useMapScreenViewModel", () => {
       status: "denied",
     });
 
+    const undefined_firstLocation = undefined;
+
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
+      useMapScreenViewModel(
+        mockFirestoreCtrl,
+        mockNavigation,
+        undefined_firstLocation,
+      ),
     );
 
     await waitFor(() => {
@@ -103,8 +109,14 @@ describe("useMapScreenViewModel", () => {
       new Error("PermissionError"),
     );
 
+    const undefined_firstLocation = undefined;
+
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
+      useMapScreenViewModel(
+        mockFirestoreCtrl,
+        mockNavigation,
+        undefined_firstLocation,
+      ),
     );
 
     await waitFor(() => {
@@ -143,8 +155,14 @@ describe("useMapScreenViewModel", () => {
       mockChallenges,
     );
 
+    const undefined_firstLocation = undefined;
+
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
+      useMapScreenViewModel(
+        mockFirestoreCtrl,
+        mockNavigation,
+        undefined_firstLocation,
+      ),
     );
 
     await waitFor(() => {
@@ -163,8 +181,14 @@ describe("useMapScreenViewModel", () => {
       new Error("FirestoreError"),
     );
 
+    const undefined_firstLocation = undefined;
+
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
+      useMapScreenViewModel(
+        mockFirestoreCtrl,
+        mockNavigation,
+        undefined_firstLocation,
+      ),
     );
 
     await waitFor(() => {
@@ -177,8 +201,14 @@ describe("useMapScreenViewModel", () => {
     // Mock console error
     jest.spyOn(console, "error").mockImplementationOnce(() => {});
 
+    const undefined_firstLocation = undefined;
+
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
+      useMapScreenViewModel(
+        mockFirestoreCtrl,
+        mockNavigation,
+        undefined_firstLocation,
+      ),
     );
 
     await waitFor(() => {

--- a/__tests__/ViewModel-tests/map/mapScreenViewModel.test.tsx
+++ b/__tests__/ViewModel-tests/map/mapScreenViewModel.test.tsx
@@ -7,6 +7,7 @@ import FirestoreCtrl, {
   DBChallenge,
 } from "@/src/models/firebase/FirestoreCtrl";
 import { useMapScreenViewModel } from "@/src/viewmodels/map/MapScreenViewModel";
+import { GeoPoint } from "firebase/firestore";
 
 // Mock FirestoreCtrl
 jest.mock("@/src/models/firebase/FirestoreCtrl", () => {
@@ -23,32 +24,19 @@ jest.mock("expo-location", () => ({
 }));
 
 // Mock GeoPoint
-class MockGeoPoint {
-  latitude: number;
-  longitude: number;
+jest.mock("firebase/firestore", () => {
+  return {
+    GeoPoint: jest.fn().mockImplementation((lat, lng) => ({
+      latitude: lat,
+      longitude: lng,
+      isEqual: (other) =>
+        lat === other.latitude && lng === other.longitude ? true : false,
+      toJSON: () => ({ latitude: lat, longitude: lng }),
+    })),
+  };
+});
 
-  constructor(latitude: number, longitude: number) {
-    this.latitude = latitude;
-    this.longitude = longitude;
-  }
-
-  isEqual(other: MockGeoPoint): boolean {
-    return (
-      this.latitude === other.latitude && this.longitude === other.longitude
-    );
-  }
-
-  toJSON() {
-    return { latitude: this.latitude, longitude: this.longitude };
-  }
-}
-
-const defaultLocation = {
-  coords: {
-    latitude: 43.6763,
-    longitude: 7.0122,
-  },
-};
+const defaultLocation = new GeoPoint(43.6763, 7.0122);
 
 const mockNavigation = {
   navigate: jest.fn(),
@@ -72,19 +60,15 @@ describe("useMapScreenViewModel", () => {
     });
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {
       expect(requestForegroundPermissionsAsync).toHaveBeenCalled();
       expect(getCurrentPositionAsync).toHaveBeenCalled();
       expect(result.current.permission).toBe(true);
-      expect(result.current.userLocation).toEqual({
-        coords: {
-          latitude: 48.8566,
-          longitude: 2.3522,
-        },
-      });
+      expect(result.current.userLocation.latitude).toBe(48.8566);
+      expect(result.current.userLocation.longitude).toBe(2.3522);
     });
   });
 
@@ -97,12 +81,17 @@ describe("useMapScreenViewModel", () => {
     });
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {
       expect(result.current.permission).toBe(false);
-      expect(result.current.userLocation).toEqual(defaultLocation);
+      expect(result.current.userLocation.latitude).toBe(
+        defaultLocation.latitude,
+      );
+      expect(result.current.userLocation.longitude).toBe(
+        defaultLocation.longitude,
+      );
     });
   });
 
@@ -115,12 +104,17 @@ describe("useMapScreenViewModel", () => {
     );
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {
       expect(result.current.permission).toBe(false);
-      expect(result.current.userLocation).toEqual(defaultLocation);
+      expect(result.current.userLocation.latitude).toBe(
+        defaultLocation.latitude,
+      );
+      expect(result.current.userLocation.longitude).toBe(
+        defaultLocation.longitude,
+      );
     });
   });
 
@@ -134,7 +128,7 @@ describe("useMapScreenViewModel", () => {
         challenge_name: "Challenge 1",
         description: "Test Challenge 1",
         uid: "12345",
-        location: new MockGeoPoint(48.8566, 2.3522),
+        location: new GeoPoint(48.8566, 2.3522),
       },
       {
         challenge_id: "2",
@@ -150,7 +144,7 @@ describe("useMapScreenViewModel", () => {
     );
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {
@@ -170,7 +164,7 @@ describe("useMapScreenViewModel", () => {
     );
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {
@@ -184,7 +178,7 @@ describe("useMapScreenViewModel", () => {
     jest.spyOn(console, "error").mockImplementationOnce(() => {});
 
     const { result } = renderHook(() =>
-      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation),
+      useMapScreenViewModel(mockFirestoreCtrl, mockNavigation, undefined),
     );
 
     await waitFor(() => {

--- a/__tests__/types/challengeBuilder.test.tsx
+++ b/__tests__/types/challengeBuilder.test.tsx
@@ -92,8 +92,16 @@ describe("createChallenge", () => {
       .fn()
       .mockRejectedValue(new Error("Firestore error"));
 
+    const null_location = null;
+
     await expect(
-      createChallenge(mockFirestoreCtrl, "Test", "Description", null, "123"),
+      createChallenge(
+        mockFirestoreCtrl,
+        "Test",
+        "Description",
+        null_location,
+        "123",
+      ),
     ).resolves.toBeUndefined(); // Function should handle the error internally
   });
 });

--- a/__tests__/types/challengeBuilder.test.tsx
+++ b/__tests__/types/challengeBuilder.test.tsx
@@ -65,6 +65,7 @@ describe("createChallenge", () => {
       challengeData.challenge_name,
       challengeData.description,
       null,
+      "123",
       challengeData.date,
     );
 
@@ -92,7 +93,7 @@ describe("createChallenge", () => {
       .mockRejectedValue(new Error("Firestore error"));
 
     await expect(
-      createChallenge(mockFirestoreCtrl, "Test", "Description", null),
+      createChallenge(mockFirestoreCtrl, "Test", "Description", null, "123"),
     ).resolves.toBeUndefined(); // Function should handle the error internally
   });
 });

--- a/app/src/viewmodels/group/GroupScreenViewModel.tsx
+++ b/app/src/viewmodels/group/GroupScreenViewModel.tsx
@@ -37,18 +37,16 @@ export default function useGroupScreenViewModel(
       const fetchGroups = async () => {
         try {
           // Fetch groups
-          await firestoreCtrl.getGroupsByUserId(user.uid)
-            .then((groups) => {
+          await firestoreCtrl.getGroupsByUserId(user.uid).then((groups) => {
             const filteredGroups = groups.filter(
               (group) =>
                 groupId !== group.gid && group.updateDate !== undefined,
-            )
+            );
             /*const sortedGroups = filteredGroups.sort(
               (a, b) => b.updateDate.getTime() - a.updateDate.getTime(),
             );*/
             setOtherGroups(filteredGroups);
-            });
-
+          });
         } catch (error) {
           console.error("Error fetching groups: ", error);
         }


### PR DESCRIPTION
This pull request includes several changes to improve the test coverage and functionality of the ViewModel tests. The most important changes involve adding mock route parameters, updating the `useCameraViewModel` and `useMapScreenViewModel` hooks, and enhancing the `createChallenge` function.

### Mock route parameters:

* Added `mockRoute` with `group_id` parameter to the `cameraViewModel.test.tsx` file and updated all `useCameraViewModel` calls to include `mockRoute`. [[1]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dR26-R31) [[2]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL37-R43) [[3]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL50-R56) [[4]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL68-R74) [[5]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL97-R103) [[6]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dR118) [[7]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL124-R131)

### `useCameraViewModel` updates:

* Updated `useCameraViewModel` calls in `cameraViewModel.test.tsx` to include `mockRoute` to ensure the tests cover route parameter usage. [[1]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL37-R43) [[2]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL50-R56) [[3]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL68-R74) [[4]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL97-R103) [[5]](diffhunk://#diff-146c6414635d84fa6cabafb9132c0c7a18c7c99d2a0f9a32e615361d138a148dL124-R131)

### `useMapScreenViewModel` updates:

* Replaced the custom `MockGeoPoint` with the `GeoPoint` class from `firebase/firestore` in `mapScreenViewModel.test.tsx`. Updated all `useMapScreenViewModel` calls to include `undefined` for the third parameter. [[1]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5R10) [[2]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L26-R39) [[3]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L75-R71) [[4]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L100-R94) [[5]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L118-R117) [[6]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L137-R131) [[7]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L153-R147) [[8]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L173-R167) [[9]](diffhunk://#diff-7f5ec2b7a4c1cf6ca370c7355372d133488c04235ee2932d47beb31774d849d5L187-R181)

### `createChallenge` function enhancements:

* Added `group_id` parameter to the `createChallenge` function calls in `createChallengeViewModel.test.tsx` and `challengeBuilder.test.tsx`. [[1]](diffhunk://#diff-43c9d25de18fe518332acaed76bcd130fcfb8eb4ee570c13305f932a3a4553e3R155-R159) [[2]](diffhunk://#diff-2185724de776e546315ad90954fd85c289d493bb451eddcc61d89807e1208238R68) [[3]](diffhunk://#diff-2185724de776e546315ad90954fd85c289d493bb451eddcc61d89807e1208238L95-R96)

### General improvements:

* Mocked `FirestoreCtrl` in `createChallengeViewModel.test.tsx` and updated related tests to use the mock implementation. [[1]](diffhunk://#diff-43c9d25de18fe518332acaed76bcd130fcfb8eb4ee570c13305f932a3a4553e3R8) [[2]](diffhunk://#diff-43c9d25de18fe518332acaed76bcd130fcfb8eb4ee570c13305f932a3a4553e3R23-L33)