### PR TITLE
test: add of tests for groupBuilder

### DIFF
--- a/__tests__/types/groupBuilder.test.tsx
+++ b/__tests__/types/groupBuilder.test.tsx
@@ -1,0 +1,79 @@
+import FirestoreCtrl from "@/src/models/firebase/FirestoreCtrl";
+jest.mock("@/src/models/firebase/FirestoreCtrl");
+import { createGroup } from "@/types/GroupBuilder";
+
+describe("createGroup Function", () => {
+  let firestoreCtrl;
+
+  beforeEach(() => {
+    firestoreCtrl = new FirestoreCtrl();
+
+    jest.clearAllMocks();
+
+    // Mock methods with appropriate return values
+    firestoreCtrl.getUser = jest.fn().mockResolvedValue({
+      uid: "user-123",
+      name: "Test User",
+    });
+
+    firestoreCtrl.newGroup = jest
+      .fn()
+      .mockResolvedValue({ name: "Test Group" });
+    firestoreCtrl.addGroupToMemberGroups = jest
+      .fn()
+      .mockResolvedValue({ name: "Test Group" });
+  });
+
+  it("creates a group successfully and assigns it to the user", async () => {
+    const groupName = "Test Group";
+    const challengeTitle = "Test Challenge";
+    const members = ["member-1", "member-2"];
+    const updateDate = new Date();
+
+    await createGroup(
+      firestoreCtrl,
+      groupName,
+      challengeTitle,
+      members,
+      updateDate,
+    );
+
+    expect(firestoreCtrl.getUser).toHaveBeenCalledTimes(1);
+    expect(firestoreCtrl.newGroup).toHaveBeenCalledWith({
+      name: groupName,
+      challengeTitle: challengeTitle,
+      members: members,
+      updateDate: updateDate,
+    });
+    expect(firestoreCtrl.addGroupToMemberGroups).toHaveBeenCalledWith(
+      "user-123",
+      groupName,
+    );
+  });
+
+  it("handles errors when creating a group", async () => {
+    const error = new Error("Failed to create group");
+    firestoreCtrl.getUser.mockRejectedValueOnce(error);
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+    const groupName = "Test Group";
+    const challengeTitle = "Test Challenge";
+    const members = ["member-1", "member-2"];
+    const updateDate = new Date();
+
+    await createGroup(
+      firestoreCtrl,
+      groupName,
+      challengeTitle,
+      members,
+      updateDate,
+    );
+
+    expect(firestoreCtrl.getUser).toHaveBeenCalledTimes(1);
+    expect(firestoreCtrl.newGroup).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith("Error creating group: ", error);
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
This pull request introduces unit tests for the `createGroup` function in the `__tests__/types/groupBuilder.test.tsx` file. The tests ensure that the function behaves correctly for successful group creation and error handling.

Unit tests for `createGroup` function:

* Implemented a test case to verify successful group creation and assignment to the user.
* Implemented a test case to handle errors during group creation and verify appropriate error logging.