### PR TITLE
Fix/final UI

### DIFF
--- a/__tests__/View-tests/home/maximiseScreen.test.tsx
+++ b/__tests__/View-tests/home/maximiseScreen.test.tsx
@@ -97,44 +97,6 @@ describe("MaximizeScreen UI Tests", () => {
     });
   });
 
-  it("handles double-tap to like the post", () => {
-    const mockToggleLike = jest.fn();
-    jest
-      .spyOn(
-        require("@/src/viewmodels/home/MaximizeScreenViewModel"),
-        "useMaximizeScreenViewModel",
-      )
-      .mockReturnValue({
-        toggleLike: mockToggleLike,
-        isLiked: false,
-        likeList: [],
-        commentList: [],
-        postDate: new Date(),
-        postUser: mockUser,
-        postDescription: "A test challenge",
-        postImage: "https://example.com/test-image.jpg",
-        showGuestPopup: jest.fn(),
-        setShowGuestPopup: jest.fn(),
-        handleUserInteraction: jest.fn(() => {
-          mockToggleLike();
-        }),
-      });
-
-    const { getByTestId } = render(
-      <MaximizeScreen
-        user={mockUser}
-        navigation={mockNavigation}
-        route={mockRoute}
-      />,
-    );
-
-    const postImage = getByTestId("post-image");
-    fireEvent.press(postImage);
-    fireEvent.press(postImage); // Simulate double-tap
-
-    expect(mockToggleLike).toHaveBeenCalled();
-  });
-
   it("handles liking a post", async () => {
     const { getByTestId } = render(
       <MaximizeScreen

--- a/__tests__/e2e/AddFriendsStateFlow.test.tsx
+++ b/__tests__/e2e/AddFriendsStateFlow.test.tsx
@@ -342,9 +342,7 @@ describe("Send a friend request that is accepted and comment a friend's post", (
     fireEvent.press(testerNavigation2.getByTestId("friends-button"));
 
     // Verify the Friend's post is displayed
-    expect(
-      testerNavigation2.getByTestId("challenge-id-0"),
-    ).toBeTruthy();
+    expect(testerNavigation2.getByTestId("challenge-id-0")).toBeTruthy();
 
     // Simulate user wanting to comment the friend's post
     fireEvent.press(testerNavigation2.getByTestId("add-a-comment"));

--- a/__tests__/e2e/AddFriendsStateFlow.test.tsx
+++ b/__tests__/e2e/AddFriendsStateFlow.test.tsx
@@ -343,7 +343,7 @@ describe("Send a friend request that is accepted and comment a friend's post", (
 
     // Verify the Friend's post is displayed
     expect(
-      testerNavigation2.getByTestId("challenge-id-Home Challenge Test Caption"),
+      testerNavigation2.getByTestId("challenge-id-0"),
     ).toBeTruthy();
 
     // Simulate user wanting to comment the friend's post

--- a/__tests__/e2e/GuestSignUpStateFlow.test.tsx
+++ b/__tests__/e2e/GuestSignUpStateFlow.test.tsx
@@ -386,6 +386,6 @@ describe("Guest User sign up and post", () => {
     });
 
     // Verify the new challenge was posted
-    expect(getByTestId("challenge-id-Test Challenge Caption")).toBeTruthy();
+    expect(getByTestId("challenge-id-0")).toBeTruthy();
   });
 });

--- a/app/src/viewmodels/home/MaximizeScreenViewModel.tsx
+++ b/app/src/viewmodels/home/MaximizeScreenViewModel.tsx
@@ -136,8 +136,7 @@ export function useMaximizeScreenViewModel(
   };
 
   const postDate: Date = challenge.date ? challenge.date : new Date();
-  const postCaption =
-    challenge.caption == "" ? "Secret Challenge" : challenge.caption;
+  const postCaption = challenge.caption ?? "";
 
   return {
     commentText,

--- a/app/src/views/home/home_screen.tsx
+++ b/app/src/views/home/home_screen.tsx
@@ -266,7 +266,7 @@ export default function HomeScreen({
       <BottomBar
         leftIcon="map-outline"
         centerIcon="camera-outline"
-        rightIcon="trophy-outline"
+        rightIcon="apps-outline"
         leftAction={() => handleRestrictedAccess("MapScreen")}
         centerAction={() => {
           if (userIsGuest) {

--- a/app/src/views/home/maximize_screen.tsx
+++ b/app/src/views/home/maximize_screen.tsx
@@ -127,8 +127,7 @@ export default function MaximizeScreen({
         </ThemedView>
 
         {/* Post Image with Double Tap */}
-        <TouchableWithoutFeedback
-        >
+        <TouchableWithoutFeedback>
           <ThemedView style={styles.imageContainer}>
             <Image
               testID="post-image"
@@ -188,7 +187,7 @@ export default function MaximizeScreen({
         {/* Comment List */}
         <ThemedView style={styles.commentList} colorType="transparent">
           {commentList.length === 0 ? (
-            <ThemedText style={{paddingLeft: 25}}>No comments yet</ThemedText>
+            <ThemedText style={{ paddingLeft: 25 }}>No comments yet</ThemedText>
           ) : (
             commentList.map((comment, index) => (
               <SingleComment

--- a/app/src/views/home/maximize_screen.tsx
+++ b/app/src/views/home/maximize_screen.tsx
@@ -93,6 +93,8 @@ export default function MaximizeScreen({
                   year: "numeric",
                   month: "short",
                   day: "numeric",
+                  hour: "numeric",
+                  minute: "numeric",
                 })}
               </ThemedText>
             </ThemedView>
@@ -126,7 +128,6 @@ export default function MaximizeScreen({
 
         {/* Post Image with Double Tap */}
         <TouchableWithoutFeedback
-          onPress={() => handleUserInteraction("like", toggleLike)}
         >
           <ThemedView style={styles.imageContainer}>
             <Image
@@ -187,7 +188,7 @@ export default function MaximizeScreen({
         {/* Comment List */}
         <ThemedView style={styles.commentList} colorType="transparent">
           {commentList.length === 0 ? (
-            <ThemedText>No comments yet</ThemedText>
+            <ThemedText style={{paddingLeft: 25}}>No comments yet</ThemedText>
           ) : (
             commentList.map((comment, index) => (
               <SingleComment

--- a/app/src/views/home/memories_screen.tsx
+++ b/app/src/views/home/memories_screen.tsx
@@ -66,8 +66,8 @@ export default function MemoriesScreen({
     <ThemedView style={styles.bigContainer} testID="memories-screen">
       <TopBar
         title="Strive"
-        leftIcon="people-outline"
-        leftAction={() => handleRestrictedAccess("Friends")}
+        leftIcon="arrow-back"
+        leftAction={() => handleRestrictedAccess("Home")}
         rightIcon={
           userIsGuest || !user.image_id ? "person-circle-outline" : icon
         }


### PR DESCRIPTION
This pull request includes several changes to the UI tests, view models, and screen components in the project. The most important changes focus on updating test identifiers, modifying the behavior of the `MaximizeScreen` component, and adjusting icons and text styles in various screens.

### UI Tests:

* Removed the test for double-tap to like a post from `maximiseScreen.test.tsx`.
* Updated test identifiers in `AddFriendsStateFlow.test.tsx` and `GuestSignUpStateFlow.test.tsx` to use a generic challenge ID (`challenge-id-0`) [[1]](diffhunk://#diff-cf14511cc481e1997d69c7710b9bc795f41f4f83aeaf0b7e0edc47da03efe16cL346-R346) [[2]](diffhunk://#diff-3ee3883e03baed5a0c3a7cf3b99913aa8da2ad59d5aa330c9bc1c2b4b81fde74L389-R389).

### View Models:

* Simplified the `postCaption` assignment in `useMaximizeScreenViewModel` by using the nullish coalescing operator.

### Screen Components:

* Changed the right icon in the `BottomBar` of the `HomeScreen` from `trophy-outline` to `apps-outline`.
* Added hours and minutes to the date display in the `MaximizeScreen`.
* Removed the double-tap like functionality from the `MaximizeScreen`.
* Adjusted the padding for the "No comments yet" text in the `MaximizeScreen`.
* Updated the left icon and action in the `TopBar` of the `MemoriesScreen` to navigate back to the `Home` screen.